### PR TITLE
Fix missing imports in Map_

### DIFF
--- a/src/pm/core/MapPortion.hx
+++ b/src/pm/core/MapPortion.hx
@@ -1,5 +1,6 @@
 package pm.core;
 
+import pm.core.AutoTiles;
 import pm.system.MapObject;
 import pm.core.Types.StructMapElementCollision;
 import pm.core.Enums.ElementMapKind;

--- a/src/pm/scene/Map_.hx
+++ b/src/pm/scene/Map_.hx
@@ -1,9 +1,18 @@
 package pm.scene;
 
+import pm.core.Player;
 import pm.core.MapPortion;
 import pm.core.TextureBundle;
+import pm.core.Vector2;
 import pm.core.Vector3;
 import pm.core.Frame;
+import pm.core.Battler;
+import pm.core.Portion;
+import pm.core.Position;
+import pm.core.Enums.PictureKind;
+import pm.core.Enums.TargetKind;
+import pm.core.Enums.Orientation;
+import pm.core.Enums.EffectSpecialActionKind;
 import js.three.ShaderMaterial;
 
 /** @class


### PR DESCRIPTION
Adds the missing imports in `Map_` as well as a msisin import in `MapPortion` so that we can correctly import `Map_` without issues.