### PR TITLE
Add structInit build macro

### DIFF
--- a/compile.hxml
+++ b/compile.hxml
@@ -4,7 +4,8 @@
 -lib toy-box
 -lib electron
 -lib jsImport
-
+-lib tink_core
+-lib tink_macro
 # Code Directory
 -cp src
 

--- a/haxe_libraries/tink_core.hxml
+++ b/haxe_libraries/tink_core.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "haxelib:/tink_core#2.0.2" into tink_core/2.0.2/haxelib
+-cp ${HAXE_LIBCACHE}/tink_core/2.0.2/haxelib/src
+-D tink_core=2.0.2

--- a/haxe_libraries/tink_macro.hxml
+++ b/haxe_libraries/tink_macro.hxml
@@ -1,0 +1,4 @@
+# @install: lix --silent download "haxelib:/tink_macro#1.0.0" into tink_macro/1.0.0/haxelib
+-lib tink_core
+-cp ${HAXE_LIBCACHE}/tink_macro/1.0.0/haxelib/src
+-D tink_macro=1.0.0

--- a/haxelib.json
+++ b/haxelib.json
@@ -14,6 +14,7 @@
     "jsImport": "",
     "toy-box": "", 
     "threejs" :"",
-    "howlerjs":"" 
+    "howlerjs":"" ,
+    "tink_macro": ""
   }
 }

--- a/src/macros/BuildMacros.hx
+++ b/src/macros/BuildMacros.hx
@@ -1,11 +1,12 @@
 package macros;
 
+import haxe.macro.Expr.Access;
 import sys.io.File;
 import haxe.macro.Expr.Field;
 import haxe.macro.Context;
-import haxe.macro.Expr;
-import haxe.macro.Type;
 import sys.FileSystem;
+import tink.macro.ClassBuilder;
+import tink.macro.Types;
 
 using Lambda;
 using core.StringExtensions;
@@ -89,5 +90,26 @@ class BuildMacros {
       traverseFiles(traverseFiles, path, file);
     });
     return fields;
+  }
+
+  macro public static function structInitDefaults(): Array<Field> {
+    var builder = new ClassBuilder();
+    var constructor = builder.getConstructor();
+    var fields = builder.export();
+
+    for (local in fields.keyValueIterator()) {
+      if (local.value.kind.getName() == 'FVar') {
+        var isPrivate: Bool = local.value.access.contains(Access.APublic);
+        var isPublic: Bool = local.value.access.length <= 0 && !isPrivate;
+        var isRequired = local.value.meta.exists(i -> i.name == 'required');
+        var name = local.value.name;
+        var type = Types.toComplex(local.value.kind.getParameters()[0]);
+        if (isPublic) {
+          constructor.addArg(name, type, null, !isRequired);
+        }
+      }
+    }
+
+    return builder.export();
   }
 }

--- a/src/macros/BuildMacros.hx
+++ b/src/macros/BuildMacros.hx
@@ -99,8 +99,8 @@ class BuildMacros {
 
     for (local in fields.keyValueIterator()) {
       if (local.value.kind.getName() == 'FVar') {
-        var isPrivate: Bool = local.value.access.contains(Access.APublic);
-        var isPublic: Bool = local.value.access.length <= 0 && !isPrivate;
+        var isPrivate = local.value.access.contains(Access.APublic);
+        var isPublic = local.value.access.length <= 0 && !isPrivate;
         var isRequired = local.value.meta.exists(i -> i.name == 'required');
         var name = local.value.name;
         var type = Types.toComplex(local.value.kind.getParameters()[0]);


### PR DESCRIPTION
Adds a build macro for automatically filling out the constructor with all public vars of the class. This PR also adds `tink_macro` which requires `tink_core`

All fields are considered public unless its access modifier is set to private and all fields are optional unless its meta contains `@required`

```js
import macros.BuildMacros;

@:build(macros.BuildMacros.structInitDefaults())
@:structInit
class Gauge extends Bitmap {
  @required // This is to let the macro know its a required field
  var value: Float;
  var max: Float;
  private var rate: Float; // This won't be added to constructor since its private
  var text: String;

  public function new(/* values, ?max, ?text */) {
    super();
    // set defaults
  }
}
```