### PR TITLE
Updates to only compile plugin copy details and run napkin once

### DIFF
--- a/src/core/Macros.hx
+++ b/src/core/Macros.hx
@@ -32,10 +32,10 @@ class Macros {
 
         if (CI_ENV) {
           File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
-          return
+          return;
         }
         File.copy(pluginsDetailsPath, rootDetailsPath);
-        Sys.command('npx prettier ./details.json --write');
+        Sys.command('npx', ['prettier', './details.json', '--write']);
         File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
         Compiler.setOutput('${Compiler.getOutput()}code.js');
       }

--- a/src/core/Macros.hx
+++ b/src/core/Macros.hx
@@ -29,6 +29,9 @@ class Macros {
       if (FileSystem.exists(pluginDir)) {
         var distFilepath = '${Sys.getCwd()}details.json';
         var filepath = '${pluginDir}/${pluginName}/details.json';
+        if (CI_ENV) {
+          File.copy(distFilepath, '${Compiler.getOutput()}details.json');
+        }
         File.copy(filepath, distFilepath);
         Sys.command('npx prettier ./details.json --write');
         File.copy(filepath, '${Compiler.getOutput()}details.json');

--- a/src/core/Macros.hx
+++ b/src/core/Macros.hx
@@ -32,11 +32,11 @@ class Macros {
 
         if (CI_ENV) {
           File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
-          return;
+        } else {
+          File.copy(pluginsDetailsPath, rootDetailsPath);
+          Sys.command('npx', ['prettier', './details.json', '--write']);
+          File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
         }
-        File.copy(pluginsDetailsPath, rootDetailsPath);
-        Sys.command('npx', ['prettier', './details.json', '--write']);
-        File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
         Compiler.setOutput('${Compiler.getOutput()}code.js');
       }
     }

--- a/src/core/Macros.hx
+++ b/src/core/Macros.hx
@@ -27,14 +27,16 @@ class Macros {
     var pluginName = getPluginName();
     if (pluginName != null) {
       if (FileSystem.exists(pluginDir)) {
-        var distFilepath = '${Sys.getCwd()}details.json';
-        var filepath = '${pluginDir}/${pluginName}/details.json';
+        var rootDetailsPath = '${Sys.getCwd()}details.json';
+        var pluginsDetailsPath = '${pluginDir}/${pluginName}/details.json';
+
         if (CI_ENV) {
-          File.copy(distFilepath, '${Compiler.getOutput()}details.json');
+          File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
+          return
         }
-        File.copy(filepath, distFilepath);
+        File.copy(pluginsDetailsPath, rootDetailsPath);
         Sys.command('npx prettier ./details.json --write');
-        File.copy(filepath, '${Compiler.getOutput()}details.json');
+        File.copy(rootDetailsPath, '${Compiler.getOutput()}details.json');
         Compiler.setOutput('${Compiler.getOutput()}code.js');
       }
     }


### PR DESCRIPTION
- This will remove the need to use `--each` compiler flag.
- It will only copy `details.json` once from game plugin's directory to root of project and from there copy to the directory set in the `compile.hxml`
   - It will only copy the `details.json` from the game's plugin directory if not in a CI enviroment, otherwise it copies the one in the root of project.
- Will only run `npx napkin` once in on the directory set by `compile.hxml`